### PR TITLE
feat(compose): Add detailed parsing for Text, Background, and Border

### DIFF
--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/UInspectorComposeService.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/UInspectorComposeService.kt
@@ -31,12 +31,12 @@ class UInspectorComposeService : UInspectorPluginService {
         plugins.prepend(UInspectorChildPanelPlugin::class.java, UInspectorComposeChildPanelPlugin())
         plugins.append(LayerFactoryPlugin::class.java, ComposeLayerFactoryPlugin())
         plugins.append(HitTestFactoryPlugin::class.java, ComposeHitTestFactoryPlugin())
-        plugins.append(ComposePropertiesParserFactory::class.java, DefaultComposeModifiersParserFactory())
+        plugins.append(ComposePropertiesParserFactory::class.java, DefaultComposeModifiersParserFactory(context))
         plugins.append(HierarchyExtraInfoPlugin::class.java, ComposeHierarchyExtraInfoPlugin())
     }
 
     companion object {
 
-        const val PluginKey = "JetpackCompose"
+        const val PLUGIN_KEY = "JetpackCompose"
     }
 }

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/hirarchy/ComposeLayerFactoryPlugin.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/hirarchy/ComposeLayerFactoryPlugin.kt
@@ -3,7 +3,7 @@ package com.pitaya.mobile.uinspector.optional.compose.hirarchy
 import android.view.View
 import com.pitaya.mobile.uinspector.hierarchy.Layer
 import com.pitaya.mobile.uinspector.hierarchy.LayerFactoryPlugin
-import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PluginKey
+import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PLUGIN_KEY
 import com.pitaya.mobile.uinspector.optional.compose.inspect.mightBeComposeView
 
 /**
@@ -12,7 +12,7 @@ import com.pitaya.mobile.uinspector.optional.compose.inspect.mightBeComposeView
  */
 class ComposeLayerFactoryPlugin : LayerFactoryPlugin {
 
-    override val uniqueKey: String = PluginKey
+    override val uniqueKey: String = PLUGIN_KEY
 
     override fun create(view: View): Layer? {
         if (view.mightBeComposeView) {

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/hirarchy/extra/ComposeHierarchyExtraInfoPlugin.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/hirarchy/extra/ComposeHierarchyExtraInfoPlugin.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import com.pitaya.mobile.uinspector.hierarchy.HierarchyExtraInfo
 import com.pitaya.mobile.uinspector.hierarchy.HierarchyExtraInfoPlugin
 import com.pitaya.mobile.uinspector.hierarchy.Layer
-import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PluginKey
+import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PLUGIN_KEY
 
 /**
  * @author YvesCheung
@@ -12,7 +12,7 @@ import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Co
  */
 class ComposeHierarchyExtraInfoPlugin : HierarchyExtraInfoPlugin {
 
-    override val uniqueKey: String = PluginKey
+    override val uniqueKey: String = PLUGIN_KEY
 
     override fun create(activity: Activity, targetLayer: Layer): Set<HierarchyExtraInfo> {
         return setOf(ComposeSourceLocationExtraInfo(activity))

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/BackgroundModifierParser.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/BackgroundModifierParser.kt
@@ -1,0 +1,39 @@
+package com.pitaya.mobile.uinspector.optional.compose.properties
+
+import androidx.compose.ui.Modifier
+import com.pitaya.mobile.uinspector.optional.compose.util.colorToString
+import com.pitaya.mobile.uinspector.optional.compose.util.simpleName
+import com.pitaya.mobile.uinspector.optional.compose.util.tryGetField
+import com.pitaya.mobile.uinspector.util.canonicalName
+
+/**
+ * @author hautc11
+ * 2025/11/20
+ */
+class BackgroundModifierParser(private val modifier: Modifier) : ComposePropertiesParser {
+
+    override val priority: Int = 10
+
+    override fun parse(props: MutableMap<String, Any?>) {
+        val color = modifier.tryGetField<Any>("color")
+        if (color != null) {
+            props["backgroundColor"] = colorToString(color)
+        } else {
+            val brush = modifier.tryGetField<Any>("brush")
+            if (brush != null) {
+                props["backgroundBrush"] = brush.simpleName
+            }
+        }
+        val shape = modifier.tryGetField<Any>("shape")
+        if (shape != null) {
+            props["backgroundShape"] = shape.toString()
+        }
+    }
+
+    companion object {
+
+        fun accept(modifier: Modifier): Boolean {
+            return modifier.canonicalName.contains("Background")
+        }
+    }
+}

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/BorderModifierParser.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/BorderModifierParser.kt
@@ -1,0 +1,45 @@
+package com.pitaya.mobile.uinspector.optional.compose.properties
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.pitaya.mobile.uinspector.optional.compose.util.colorToString
+import com.pitaya.mobile.uinspector.optional.compose.util.tryGetField
+import com.pitaya.mobile.uinspector.util.canonicalName
+
+/**
+ * @author hautc11
+ * 2025/11/20
+ */
+class BorderModifierParser(private val modifier: Modifier) : ComposePropertiesParser {
+
+    override val priority: Int = 10
+
+
+    override fun parse(props: MutableMap<String, Any?>) {
+        val rawWidth = modifier.tryGetField<Any?>("width")
+        val widthPx = rawWidth as? Float
+
+        if (widthPx != null && widthPx > 0) {
+            props["borderWidth"] = "${widthPx.toInt()}.dp"
+
+            val brush = modifier.tryGetField<Any>("brush")
+            if (brush != null) {
+                val color = brush.tryGetField<Color>("value")
+                if (color != null) {
+                    props["borderColor"] = colorToString(color)
+                }
+            }
+            val shape = modifier.tryGetField<Any>("shape")
+            if (shape != null) {
+                props["borderShape"] = shape
+            }
+        }
+    }
+
+    companion object {
+
+        fun accept(modifier: Modifier): Boolean {
+            return modifier.canonicalName.contains("Border")
+        }
+    }
+}

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/DefaultComposeModifiersParserFactory.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/DefaultComposeModifiersParserFactory.kt
@@ -7,7 +7,9 @@ import com.pitaya.mobile.uinspector.optional.compose.hirarchy.ComposeView
  * @author YvesCheung
  * 2021/2/2
  */
-class DefaultComposeModifiersParserFactory : ComposePropertiesParserFactory {
+class DefaultComposeModifiersParserFactory(
+    private val context: android.content.Context
+) : ComposePropertiesParserFactory {
 
     override val uniqueKey: String = "Default"
 
@@ -27,8 +29,18 @@ class DefaultComposeModifiersParserFactory : ComposePropertiesParserFactory {
 
                 PaddingModifierParser.accept(modifier) -> null
 
+                BorderModifierParser.accept(modifier) -> {
+                    BorderModifierParser(modifier)
+                }
+
+                BackgroundModifierParser.accept(modifier) ->
+                    BackgroundModifierParser(modifier)
+
+                TextStringSimpleElementParser.accept(modifier) ->
+                    TextStringSimpleElementParser(modifier)
+
                 else -> InspectableModifierParser(modifier)
             }
-        } + listOf(BasicParser(view), SemanticsModifierParser(view))
+        } + listOf(BasicParser(view), SemanticsModifierParser(context, view))
     }
 }

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/SemanticsModifierParser.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/SemanticsModifierParser.kt
@@ -1,5 +1,9 @@
 package com.pitaya.mobile.uinspector.optional.compose.properties
 
+import android.content.Context
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.semantics.SemanticsActions.GetTextLayoutResult
+import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties.CollectionInfo
 import androidx.compose.ui.semantics.SemanticsProperties.CollectionItemInfo
 import androidx.compose.ui.semantics.SemanticsProperties.ContentDescription
@@ -20,15 +24,21 @@ import androidx.compose.ui.semantics.SemanticsProperties.ToggleableState
 import androidx.compose.ui.semantics.SemanticsProperties.VerticalScrollAxisRange
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
-import com.pitaya.mobile.uinspector.util.Output
+import androidx.compose.ui.unit.isSpecified
 import com.pitaya.mobile.uinspector.optional.compose.hirarchy.ComposeView
+import com.pitaya.mobile.uinspector.optional.compose.util.colorToString
+import com.pitaya.mobile.uinspector.optional.compose.util.tryGetField
+import com.pitaya.mobile.uinspector.util.Output
 import com.pitaya.mobile.uinspector.util.quote
 
 /**
- * @author YvesCheung
+ * @author YvesCheung & hautc11
  * 2021/12/1
  */
-class SemanticsModifierParser(val view: ComposeView) : ComposePropertiesParser {
+class SemanticsModifierParser(
+    private val context: Context,
+    val view: ComposeView
+) : ComposePropertiesParser {
 
     override val priority: Int = 10000
 
@@ -52,9 +62,14 @@ class SemanticsModifierParser(val view: ComposeView) : ComposePropertiesParser {
 
         parseSemanticsProperty(Role)
 
-        parseSemanticsProperty(Text) { stringList ->
-            stringList?.joinToString { annotatedString -> "\"${annotatedString}\"" }
+        parseSemanticsProperty(Text) {
+            it?.firstOrNull()?.let { annotatedString ->
+                props["text"] = annotatedString.text.quote()
+            }
+            null
         }
+
+        parseTextLayoutResult(props, configs)
 
         parseSemanticsProperty(EditableText)
 
@@ -98,5 +113,61 @@ class SemanticsModifierParser(val view: ComposeView) : ComposePropertiesParser {
         parseSemanticsProperty(ToggleableState)
 
         parseSemanticsProperty(Error)
+    }
+
+    private fun parseTextLayoutResult(
+        props: MutableMap<String, Any?>,
+        configs: List<SemanticsConfiguration>
+    ) {
+        val getTextLayoutResult = configs.firstNotNullOfOrNull { it.getOrNull(GetTextLayoutResult) }
+        if (getTextLayoutResult?.action != null) {
+            val layoutResults = mutableListOf<androidx.compose.ui.text.TextLayoutResult>()
+            try {
+                val success = getTextLayoutResult.action?.invoke(layoutResults)
+                if (success == true && layoutResults.isNotEmpty()) {
+                    val textLayoutResult = layoutResults.first()
+                    val style = textLayoutResult.layoutInput.style
+
+                    if (style.fontSize.isSpecified) {
+                        props["fontSize"] = style.fontSize.toString()
+                    }
+                    style.fontWeight?.let { props["fontWeight"] = it.weight }
+                    style.fontFamily?.let {
+                        if (it.javaClass.simpleName == "FontListFontFamily") {
+                            val fonts = it.tryGetField<List<Any>>("fonts")
+                            if (fonts != null) {
+                                val fontNames = fonts.map { font ->
+                                    if (font.javaClass.simpleName == "ResourceFont") {
+                                        val resId = font.tryGetField<Int>("resId")
+                                        if (resId != null) {
+                                            try {
+                                                "R.font.${context.resources.getResourceEntryName(resId)}"
+                                            } catch (_: Exception) {
+                                                "resId=$resId"
+                                            }
+                                        } else {
+                                            "ResourceFont"
+                                        }
+                                    } else {
+                                        font.javaClass.simpleName
+                                    }
+                                }
+                                props["fontFamily"] = fontNames.joinToString(",\n")
+                            } else {
+                                props["fontFamily"] = it.toString()
+                            }
+                        } else {
+                            props["fontFamily"] = it.toString()
+                        }
+                    }
+                    style.fontStyle?.let { props["fontStyle"] = it.toString() }
+                    if (style.color.isSpecified) {
+                        props["textColor"] = colorToString(style.color)
+                    }
+                }
+            } catch (e: Exception) {
+                props["GetTextLayoutResult_Error"] = e.message ?: "Unknown error"
+            }
+        }
     }
 }

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/TextStringSimpleElementParser.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/properties/TextStringSimpleElementParser.kt
@@ -1,0 +1,34 @@
+package com.pitaya.mobile.uinspector.optional.compose.properties
+
+import androidx.compose.ui.Modifier
+import com.pitaya.mobile.uinspector.optional.compose.util.tryGetField
+import com.pitaya.mobile.uinspector.util.canonicalName
+
+/**
+ * @author hautc11
+ * 2025/11/20
+ */
+class TextStringSimpleElementParser(private val modifier: Modifier) : ComposePropertiesParser {
+
+    override val priority: Int = 10
+
+    override fun parse(props: MutableMap<String, Any?>) {
+        modifier.tryGetField<Int>("minLines")?.let { props["minLines"] = it }
+        modifier.tryGetField<Int>("maxLines")?.let {
+            props["maxLines"] = if (it != Int.MAX_VALUE) {
+                it
+            } else {
+                "No limited."
+            }
+        }
+        modifier.tryGetField<Any>("overflow")?.let { props["overflow"] = it.toString() }
+        modifier.tryGetField<Boolean>("softWrap")?.let { props["softWrap"] = it }
+    }
+
+    companion object {
+
+        fun accept(modifier: Modifier): Boolean {
+            return modifier.canonicalName.endsWith("TextStringSimpleElement")
+        }
+    }
+}

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/touch/ComposeHitTestFactoryPlugin.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/touch/ComposeHitTestFactoryPlugin.kt
@@ -2,7 +2,7 @@ package com.pitaya.mobile.uinspector.optional.compose.touch
 
 import com.pitaya.mobile.uinspector.hierarchy.HitTest
 import com.pitaya.mobile.uinspector.hierarchy.HitTestFactoryPlugin
-import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PluginKey
+import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Companion.PLUGIN_KEY
 
 /**
  * @author YvesCheung
@@ -10,7 +10,7 @@ import com.pitaya.mobile.uinspector.optional.compose.UInspectorComposeService.Co
  */
 class ComposeHitTestFactoryPlugin : HitTestFactoryPlugin {
 
-    override val uniqueKey: String = PluginKey
+    override val uniqueKey: String = PLUGIN_KEY
 
     override fun create(delegate: HitTest): HitTest = ComposeHitTest(delegate)
 }

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Color.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Color.kt
@@ -1,0 +1,17 @@
+package com.pitaya.mobile.uinspector.optional.compose.util
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
+fun colorToString(color: Any): String {
+    val finalColor = when (color) {
+        is Color -> color
+        is Long -> Color(color.toULong())
+        else -> null
+    }
+
+    if (finalColor != null) {
+        return "0x" + Integer.toHexString(finalColor.toArgb()).uppercase()
+    }
+    return color.toString()
+}

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Reflection.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Reflection.kt
@@ -1,0 +1,30 @@
+package com.pitaya.mobile.uinspector.optional.compose.util
+
+import java.lang.reflect.Field
+
+/**
+ * @author hautc11
+ * 2025/11/20
+ */
+inline fun <reified T> Any.tryGetField(name: String): T? {
+    return try {
+        val field = this::class.java.findField(name)
+        field.isAccessible = true
+        field.get(this) as T?
+    } catch (_: Exception) {
+        null
+    }
+}
+
+fun Class<*>.findField(name: String): Field {
+    var c: Class<*>? = this
+    while (c != null && c != Any::class.java) {
+        try {
+            return c.getDeclaredField(name)
+        } catch (_: NoSuchFieldException) {
+            //ignore
+        }
+        c = c.superclass
+    }
+    throw NoSuchFieldException("Cannot find field $name in class $this")
+}

--- a/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Util.kt
+++ b/optional/compose/src/main/java/com/pitaya/mobile/uinspector/optional/compose/util/Util.kt
@@ -1,0 +1,12 @@
+package com.pitaya.mobile.uinspector.optional.compose.util
+
+import com.pitaya.mobile.uinspector.util.canonicalName
+
+val Any.simpleName: String
+    get() {
+        var name = this.canonicalName
+        if (name.contains(".")) {
+            name = name.substring(name.lastIndexOf('.') + 1)
+        }
+        return name
+    }


### PR DESCRIPTION
The Compose property inspector was previously unable to parse detailed information for several common modifiers, often displaying only the internal element name (e.g., `BackgroundElement`, `TextStringSimpleElement`).

Related to Issue #11 

This change introduces dedicated parsers and enhances existing ones to provide detailed, human-readable properties.

Key changes:
1. **Text Properties:** Implemented a new parsing strategy that uses the `GetTextLayoutResult` semantics action to reliably extract the final, merged `TextStyle` for a `Text` composable. This provides accurate  `fontSize`, `fontWeight`, `fontFamily`, and `color` values.
2. **Background & Border:** Added new parsers to extract `backgroundColor`, `borderWidth`, and `borderColor` from their respective modifiers.
3. **Font Family Resolution:** The parser now resolves `FontFamily` resource IDs to their human-readable names (e.g., `R.font.my_font`).
